### PR TITLE
Implement extension guessing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/go-chi/hostrouter v0.0.0-20180220162504-7bff2694dfd9
 	github.com/go-chi/render v1.0.1
+	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,9 @@ github.com/go-chi/hostrouter v0.0.0-20180220162504-7bff2694dfd9 h1:6cjaGaVj38dAq
 github.com/go-chi/hostrouter v0.0.0-20180220162504-7bff2694dfd9/go.mod h1:O0Q6TlPEvjLqJu7QcX2GYOBDKkQfKmVIPsZeCy3/KJA=
 github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
+golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/webhook-server.go
+++ b/webhook-server.go
@@ -146,13 +146,15 @@ func makeHTMLMiddleware(prefix, root string) func(http.Handler) http.Handler {
 
 			// or if we already have an extension
 			parts := strings.Split(r.URL.Path, "/")
-			last := parts[len(parts)-1]
-			if strings.LastIndex(last, ".") > 0 {
-				next.ServeHTTP(w, r)
-				return
+			if len(parts) > 0 {
+				last := parts[len(parts)-1]
+				if strings.LastIndex(last, ".") > 0 {
+					next.ServeHTTP(w, r)
+					return
+				}
 			}
 
-			endingsToTry := []string{".html"}
+			endingsToTry := []string{".html", "htm"}
 			stripped := strings.TrimPrefix(r.URL.Path, prefix)
 
 			for _, ext := range endingsToTry {

--- a/webhook-server.go
+++ b/webhook-server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -100,35 +101,81 @@ func serveSubDirectory(subdir, root, baseURL string) chi.Router {
 	master := http.Dir(masterPath)
 	tags := http.Dir(tagsPath)
 
-	stableFs := http.StripPrefix("/stable", http.FileServer(stable))
-	masterFs := http.StripPrefix("/master", http.FileServer(master))
+	stablePrefix := "/stable"
+	masterPrefix := "/master"
+
+	stableFs := http.StripPrefix(stablePrefix, http.FileServer(stable))
+	masterFs := http.StripPrefix(masterPrefix, http.FileServer(master))
 	tagsFs := http.FileServer(tags)
 
 	tagsURL := fmt.Sprintf("/{tag:%s}/*", semverRegex)
 
 	r := chi.NewRouter()
 	stableRoot := fmt.Sprintf("//%s/stable%s", baseURL, root)
-	r.Get("/stable", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("Redirecting to stable: %s", stableRoot)
-		http.Redirect(w, r, stableRoot, 301)
-	})
-	r.Get("/stable/*", stableFs.ServeHTTP)
+	r.Get("/stable", http.RedirectHandler(stableRoot, 301).ServeHTTP)
+
+	r.
+		With(makeHTMLMiddleware(stablePrefix, stablePath)).
+		Get("/stable/*", stableFs.ServeHTTP)
 
 	masterRoot := fmt.Sprintf("//%s/master%s", baseURL, root)
-	r.Get("/master", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("Redirecting master to: %s", masterRoot)
-		http.Redirect(w, r, masterRoot, 301)
-	})
-	r.Get("/master/*", masterFs.ServeHTTP)
-	r.Get(tagsURL, tagsFs.ServeHTTP)
+	r.Get("/master", http.RedirectHandler(masterRoot, 301).ServeHTTP)
 
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("Redirecting / to: %s", stableRoot)
-		http.Redirect(w, r, stableRoot, 301)
-	})
+	r.
+		With(makeHTMLMiddleware(masterPrefix, masterPath)).
+		Get("/master/*", masterFs.ServeHTTP)
+
+	r.
+		With(makeHTMLMiddleware("", tagsPath)).
+		Get(tagsURL, tagsFs.ServeHTTP)
+
+	r.Get("/", http.RedirectHandler(stableRoot, 301).ServeHTTP)
 	r.NotFound(handleNotFound)
 
 	return r
+}
+
+func makeHTMLMiddleware(prefix, root string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// first, check if there's a slash at the end
+			if strings.HasSuffix(r.URL.Path, "/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// or if we already have an extension
+			parts := strings.Split(r.URL.Path, "/")
+			last := parts[len(parts)-1]
+			if strings.LastIndex(last, ".") > 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			endingsToTry := []string{".html"}
+			stripped := strings.TrimPrefix(r.URL.Path, prefix)
+
+			for _, ext := range endingsToTry {
+				path := root + stripped + ext
+				stat, err := os.Stat(path)
+				if err != nil {
+					continue
+				}
+
+				if stat.IsDir() {
+					continue
+				}
+
+				// if we drop through to here, the file exists
+				// and we should adjust the path so that it will
+				// be served!
+				r.URL.Path = r.URL.Path + ext
+				break
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func mustMkDir(p string) {


### PR DESCRIPTION
This PR makes the `.html` extension unnecessary, enabling nicer links and probably fixing some cached links that are floating around somewhere.